### PR TITLE
Rolled back change for handling kv soft-delete function

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -1,11 +1,6 @@
 provider "azurerm" {
   version = "=2.30.0"
-  features {
-    key_vault {
-      recover_soft_deleted_key_vaults = false
-      purge_soft_delete_on_destroy    = true
-    }
-  }
+  features {}
 }
 
 provider "azurerm" {


### PR DESCRIPTION

This is no longer needed in the configuration as the default setting asks Terraform to recover any deleted kv objects.

For more information, check the following documentation from terraform:

https://www.terraform.io/docs/providers/azurerm/index.html#features-2﻿
