### PR TITLE
DTSPO-5553 Switch to v2 storage

### DIFF
--- a/storage-account.tf
+++ b/storage-account.tf
@@ -9,7 +9,6 @@ module "storage_account" {
   storage_account_name     = local.account_name
   resource_group_name      = azurerm_resource_group.rg.name
   location                 = var.location
-  account_kind             = "StorageV2"
   account_tier             = "Standard"
   account_replication_type = "LRS"
   access_tier              = "Hot"

--- a/storage-account.tf
+++ b/storage-account.tf
@@ -9,7 +9,6 @@ module "storage_account" {
   storage_account_name     = local.account_name
   resource_group_name      = azurerm_resource_group.rg.name
   location                 = var.location
-  account_kind             = "BlobStorage"
   account_tier             = "Standard"
   account_replication_type = "LRS"
   access_tier              = "Hot"

--- a/storage-account.tf
+++ b/storage-account.tf
@@ -9,6 +9,7 @@ module "storage_account" {
   storage_account_name     = local.account_name
   resource_group_name      = azurerm_resource_group.rg.name
   location                 = var.location
+  account_kind             = "StorageV2"
   account_tier             = "Standard"
   account_replication_type = "LRS"
   access_tier              = "Hot"


### PR DESCRIPTION
Please see https://tools.hmcts.net/jira/browse/DTSPO-5553

This is step 1 of 2 in the Storage HA work in progress.
In order for Storage to use high availability we need to use a v2 account, currently this is using a v1 because of how it was setup.

This will be migrated in the background using an Azure migration process and then terraform ran afterwards to refresh the state