### PR TITLE
DTSPO-6371 add private endpoint provider for service bus

### DIFF
--- a/service-bus.tf
+++ b/service-bus.tf
@@ -10,6 +10,10 @@ locals {
 }
 
 module "servicebus-namespace" {
+  providers = {
+    azurerm.private-endpoint = azurerm.private-endpoint
+  }
+  
   source              = "git@github.com:hmcts/terraform-module-servicebus-namespace?ref=master"
   name                = local.servicebus_namespace_name
   location            = var.location

--- a/terraform.tf
+++ b/terraform.tf
@@ -35,6 +35,13 @@ provider "azurerm" {
   features {}
 }
 
+provider "azurerm" {
+  features {}
+  skip_provider_registration = true
+  alias                      = "private-endpoint"
+  subscription_id            = var.aks_subscription_id
+}
+
 terraform {
   backend "azurerm" {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -91,3 +91,5 @@ variable "rd_location_storage_access_tier" {
   type    = string
   default = "Cool"
 }
+
+variable "aks_subscription_id" {}


### PR DESCRIPTION
# JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6371


### Change description ###
PlatOps have made some changes to the service bus terraform module, mainly around adding the ability to enable private endpoints. We needed to add a Private Endpoint provider to allow for Private endpoints being deployed to a different Subscription to the Service Bus being created. 

This change should have no effect on anything currently deployed, but it will allow you to deploy a Service Bus with a Private Endpoint if you add the correct inputs to the module. 

More information on that can be found here: https://github.com/hmcts/terraform-module-servicebus-namespace#usage


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
