### PR TITLE
DTSPO-6371 - add service bus provider

### DIFF
--- a/service-bus.tf
+++ b/service-bus.tf
@@ -23,7 +23,7 @@ module "servicebus-namespace" {
 }
 
 module "caseworker-topic" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-topic?ref=master"
+  source                = "git@github.com:hmcts/terraform-module-servicebus-topic?ref=DTSPO-6371_azurerm_upgrade"
   name                  = local.caseworker_topic_name
   namespace_name        = module.servicebus-namespace.name
   resource_group_name   = local.resource_group_name
@@ -38,7 +38,7 @@ module "caseworker-subscription" {
 }
 
 module "judicial-topic" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-topic?ref=master"
+  source                = "git@github.com:hmcts/terraform-module-servicebus-topic?ref=DTSPO-6371_azurerm_upgrade"
   name                  = local.judicial_topic_name
   namespace_name        = module.servicebus-namespace.name
   resource_group_name   = local.resource_group_name
@@ -65,22 +65,26 @@ resource "azurerm_key_vault_secret" "caseworker-topic-primary-send-listen-shared
   name         = "caseworker-topic-primary-send-listen-shared-access-key"
   value        = module.caseworker-topic.primary_send_and_listen_shared_access_key
   key_vault_id = module.rd_key_vault.key_vault_id
+  sensitive    = true
 }
 
 resource "azurerm_key_vault_secret" "judicial-topic-primary-send-listen-shared-access-key" {
   name         = "judicial-topic-primary-send-listen-shared-access-key"
   value        = module.judicial-topic.primary_send_and_listen_shared_access_key
   key_vault_id = module.rd_key_vault.key_vault_id
+  sensitive    = true
 }
 
 resource "azurerm_key_vault_secret" "caseworker-topic-primary-connection-string" {
   name         = "caseworker-topic-primary-connection-string"
   value        = module.caseworker-topic.primary_send_and_listen_connection_string
   key_vault_id = module.rd_key_vault.key_vault_id
+  sensitive    = true
 }
 
 resource "azurerm_key_vault_secret" "judicial-topic-primary-connection-string" {
   name         = "judicial-topic-primary-connection-string"
   value        = module.judicial-topic.primary_send_and_listen_connection_string
   key_vault_id = module.rd_key_vault.key_vault_id
+  sensitive    = true
 }

--- a/service-bus.tf
+++ b/service-bus.tf
@@ -30,7 +30,7 @@ module "caseworker-topic" {
 }
 
 module "caseworker-subscription" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=master"
+  source                = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-6371_azurerm_upgrade"
   name                  = local.caseworker_subscription_name
   namespace_name        = module.servicebus-namespace.name
   topic_name            = module.caseworker-topic.name
@@ -45,7 +45,7 @@ module "judicial-topic" {
 }
 
 module "judicial-subscription" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=master"
+  source                = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-6371_azurerm_upgrade"
   name                  = local.judicial_subscription_name
   namespace_name        = module.servicebus-namespace.name
   topic_name            = module.judicial-topic.name
@@ -53,7 +53,7 @@ module "judicial-subscription" {
 }
 
 module "am-orm-judicial-test-pr-subscription" {
-  source                = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=master"
+  source                = "git@github.com:hmcts/terraform-module-servicebus-subscription?ref=DTSPO-6371_azurerm_upgrade"
   count                 = lower(var.env) == "aat" ? 1 : 0
   name                  = "am-orm-judicial-preview-functional-test"
   namespace_name        = module.servicebus-namespace.name

--- a/service-bus.tf
+++ b/service-bus.tf
@@ -65,26 +65,22 @@ resource "azurerm_key_vault_secret" "caseworker-topic-primary-send-listen-shared
   name         = "caseworker-topic-primary-send-listen-shared-access-key"
   value        = module.caseworker-topic.primary_send_and_listen_shared_access_key
   key_vault_id = module.rd_key_vault.key_vault_id
-  sensitive    = true
 }
 
 resource "azurerm_key_vault_secret" "judicial-topic-primary-send-listen-shared-access-key" {
   name         = "judicial-topic-primary-send-listen-shared-access-key"
   value        = module.judicial-topic.primary_send_and_listen_shared_access_key
   key_vault_id = module.rd_key_vault.key_vault_id
-  sensitive    = true
 }
 
 resource "azurerm_key_vault_secret" "caseworker-topic-primary-connection-string" {
   name         = "caseworker-topic-primary-connection-string"
   value        = module.caseworker-topic.primary_send_and_listen_connection_string
   key_vault_id = module.rd_key_vault.key_vault_id
-  sensitive    = true
 }
 
 resource "azurerm_key_vault_secret" "judicial-topic-primary-connection-string" {
   name         = "judicial-topic-primary-connection-string"
   value        = module.judicial-topic.primary_send_and_listen_connection_string
   key_vault_id = module.rd_key_vault.key_vault_id
-  sensitive    = true
 }

--- a/storage-account.tf
+++ b/storage-account.tf
@@ -23,7 +23,7 @@ module "storage_account" {
   location                 = var.location
   account_kind             = "StorageV2"
   account_tier             = "Standard"
-  account_replication_type = "LRS"
+  account_replication_type = "ZRS"
   access_tier              = "Hot"
 
   //  enable_blob_encryption    = true

--- a/terraform.tf
+++ b/terraform.tf
@@ -48,7 +48,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.78.0"
+      version = "~> 2.99.0"
     }
 
     azuread = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -48,7 +48,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.0.0"
+      version = "~> 3.2.0"
     }
 
     azuread = {

--- a/terraform.tf
+++ b/terraform.tf
@@ -48,7 +48,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 2.99.0"
+      version = "~> 3.0.0"
     }
 
     azuread = {


### PR DESCRIPTION
# JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6371


### Change description ###
- Service Bus Private endpoint provider added

PlatOps have made some changes to the service bus terraform module, mainly around adding the ability to enable private endpoints. We needed to add a Private Endpoint provider to allow for Private endpoints being deployed to a different Subscription to the Service Bus being created. 

This change should have no effect on anything currently deployed, but it will allow you to deploy a Service Bus with a Private Endpoint if you add the correct inputs to the module. 

More information on that can be found here: https://github.com/hmcts/terraform-module-servicebus-namespace#usage


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
