### PR TITLE
Allow Access to RefData Storage Accounts From BAIS Private Prod Subnet

### DIFF
--- a/datasources.tf
+++ b/datasources.tf
@@ -75,3 +75,16 @@ data "azurerm_subnet" "rdo_sftp_private" {
   virtual_network_name  = data.azurerm_virtual_network.rdo_sftp_vnet.name
   resource_group_name   = data.azurerm_virtual_network.rdo_sftp_vnet.resource_group_name
 }
+
+data "azurerm_virtual_network" "bau_bais_prod_vnet" {
+  provider            = azurerm.sds_prod
+  name                = "bau-bais_prod_network"
+  resource_group_name = "bau-bais_prod_network_rg"
+}
+
+data "azurerm_subnet" "bau_bais_private_prod" {
+  provider            = azurerm.sds_prod
+  name                  = "bau-bais_private_prod"
+  virtual_network_name  = data.azurerm_virtual_network.bau_bais_prod_vnet.name
+  resource_group_name   = data.azurerm_virtual_network.bau_bais_prod_vnet.resource_group_name
+}

--- a/storage-account.tf
+++ b/storage-account.tf
@@ -7,7 +7,8 @@ locals {
     data.azurerm_subnet.aks_01.id,
     data.azurerm_subnet.jenkins_subnet.id,
     data.azurerm_subnet.rdo_sftp_public.id,
-    data.azurerm_subnet.rdo_sftp_private.id
+    data.azurerm_subnet.rdo_sftp_private.id,
+    data.azurerm_subnet.bau_bais_private_prod.id
   ]
 
   cft_prod_subnets = var.env == "prod" ? [data.azurerm_subnet.prod_aks_00_subnet.id, data.azurerm_subnet.prod_aks_01_subnet.id] : []

--- a/terraform.tf
+++ b/terraform.tf
@@ -42,6 +42,12 @@ provider "azurerm" {
   subscription_id            = var.aks_subscription_id
 }
 
+provider "azurerm" {
+  alias           = "sds_prod"
+  subscription_id = "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"
+  features {}
+}
+
 terraform {
   backend "azurerm" {}
 


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15559

### Change description ###
As part of the decomissioning of the RDO globalscape instances, event rules are being migrated to the BAIS EFT globalscape instance. This PR allows access to the refdata storage accounts from the bau-bais_private_prod subnet, necessary for the refdata event rules to continue functioning on the new machine.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
