### PR TITLE
DTSRD-1205

### DIFF
--- a/storage-account-rd-data-extracts.tf
+++ b/storage-account-rd-data-extracts.tf
@@ -42,7 +42,8 @@ module "storage_account_rd_data_extract" {
   common_tags  = local.tags
   team_contact = var.team_contact
   destroy_me   = var.destroy_me
-  default_action = "Allow"
+  // Set default action to "Allow" below if you need to override the ip_rules and sa_subnets, eg to allow access to blob storage to someone outside the VPN.
+  default_action = "Deny"
 
   sa_subnets = local.all_valid_subnets
 }


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSRD-1205

### Change description ###
- Adding subnets to data extract storage account.
- Updating default_action to "Deny" - now that an external recipient has the data required this can be changed back to restricting access to the storage account - see https://tools.hmcts.net/confluence/display/DTSRD/Privileged+Access+to+Blob+Storage#PrivilegedAccesstoBlobStorage-IPaccess for details.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change
